### PR TITLE
Fix #13: ignore [dot]directives, like .size, .data, .text, etc

### DIFF
--- a/dcpu.js
+++ b/dcpu.js
@@ -148,6 +148,7 @@ var dcpuTokens = {
 	// Keywords/text
 	INSTRUCTION:"INSTRUCTION",
 	REGISTER:"REGISTER",
+	DOTDIRECTIVE:"DOT DIRECTIVE",
 	LABEL:"LABEL",
 
 	// Values
@@ -268,6 +269,9 @@ function dcpuLexer(report)
 			return [ dcpuTokens.INSTRUCTION, dcpuOpcodes[text] ];
 		if (text in dcpuRegisters)
 			return [ dcpuTokens.REGISTER, dcpuRegisters[text] ];
+		if (text != "" && text[0] == '.') {
+			return [ dcpuTokens.DOTDIRECTIVE, text ];
+		}
 
 		return [ dcpuTokens.LABEL, text ];
 	}
@@ -609,6 +613,11 @@ function dcpuAssembler(report)
 				case (dcpuTokens.SEMICOLON):
 				case (dcpuTokens.END):
 					continue;
+
+				// Skip .size, .text, .data, etc directives
+				case (dcpuTokens.DOTDIRECTIVE):
+					continue;
+
 
 				// Only accept labels and instructions
 				case (dcpuTokens.COLON):


### PR DESCRIPTION
Hi Don!
#13 really prevents people from using an output from LLVM backend in your wonderful live environment for DCPU-16 (I hope to 'steal' some ideas from you and put Clang online).

So, here is the tiny fix for #13. Please, take a look and merge, if acceptable.

I'm fine to respond to comments on the code, if any.
